### PR TITLE
Mirror max_toot_chars in presenter middleware

### DIFF
--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -89,4 +89,8 @@ class InstancePresenter < ActiveModelSerializers::Model
   def mascot
     @mascot ||= Rails.cache.fetch('site_uploads/mascot') { SiteUpload.find_by(var: 'mascot') }
   end
+
+  def max_toot_chars
+    1000
+  end
 end


### PR DESCRIPTION
Should get /about working again (while preserving character counter behavior in (legacy?) mobile clients)

This should probably be read from `StatusLengthValidator::MAX_CHARS` like in https://github.com/mastodon/mastodon/pull/16485 (and put in the `compose_form` while we're at it) but w/e